### PR TITLE
return array as middleware result instead of Rack::Response

### DIFF
--- a/lib/grape/batch/base.rb
+++ b/lib/grape/batch/base.rb
@@ -18,7 +18,8 @@ module Grape
         @logger.batch_end
 
         # Return Rack formatted response
-        Rack::Response.new(body, status, 'Content-Type' => 'application/json')
+        r = Rack::Response.new(body, status, 'Content-Type' => 'application/json')
+        [r.status, r.headers, r.body]
       end
 
       def batch_call(env)


### PR DESCRIPTION
Rack version v2.2.3 starts to fails with `NoMethodError (undefined method `[]' for nil:NilClass):`
at  rack (2.2.3) lib/rack/etag.rb:38:in `call'

because Grape Middlware returns whole Rack.Response instance, which maps to status and headers and body stay undefined resulting in this error.
To fix we need to return array with status, headers, body as it's expected by Rack middleware
